### PR TITLE
Serialize entity relations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.out
+*.pprof
+*.csv
+*.svg
+*.png

--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@
 
 ## Features
 
-* Serialize/deserialize an entire world in one line.
-* Currently only supports plain components and resources.  
-Entities that are stored in components can currently not be deserialized properly.
+* Serialize/deserialize an entire *Arche* world in one line.
+* Proper serialization of entity relations, as well as of entities stored in components.
 
 ## Installation
 

--- a/deserialize.go
+++ b/deserialize.go
@@ -51,8 +51,16 @@ func Deserialize(jsonData []byte, world *ecs.World) error {
 			return err
 		}
 
+		e := entity{}
 		components := []ecs.Component{}
 		for tpName, value := range mp {
+			if tpName == entityTag {
+				if err := json.Unmarshal(value.Bytes, &e); err != nil {
+					return err
+				}
+				continue
+			}
+
 			id := ids[tpName]
 			tp := types[id]
 

--- a/deserialize.go
+++ b/deserialize.go
@@ -13,6 +13,8 @@ import (
 // The world must be prepared the following way:
 //   - All required component types must be registered using [ecs.ComponentID]
 //   - All required resources must be added using [ecs.AddResource]
+//
+// After deserialization, it is not guaranteed that entity iteration order in queries is the same as before.
 func Deserialize(jsonData []byte, world *ecs.World) error {
 	infos := map[ecs.ID]ecs.CompInfo{}
 	ids := map[string]ecs.ID{}
@@ -38,19 +40,12 @@ func Deserialize(jsonData []byte, world *ecs.World) error {
 		return err
 	}
 
-	if err := world.UnmarshalEntities(deserial.World.Bytes); err != nil {
-		return err
-	}
+	world.SetEntityData(&deserial.World)
 
 	for _, tp := range deserial.Types {
 		if _, ok := ids[tp]; !ok {
 			return fmt.Errorf("component type is not registered: %s", tp)
 		}
-	}
-
-	entityMap := map[ecs.Entity]int{}
-	for idx, entity := range deserial.Entities {
-		entityMap[entity] = idx
 	}
 
 	for i, comps := range deserial.Components {

--- a/deserialize.go
+++ b/deserialize.go
@@ -50,7 +50,7 @@ func deserializeComponents(world *ecs.World, deserial *deserializer) error {
 	}
 
 	for i, comps := range deserial.Components {
-		entity := deserial.Entities[i]
+		entity := deserial.World.Entities[deserial.World.Alive[i]]
 
 		mp := map[string]entry{}
 

--- a/example_test.go
+++ b/example_test.go
@@ -22,7 +22,7 @@ func Example() {
 	}
 
 	// Print the resulting JSON.
-	fmt.Println(string(jsonData))
+	// fmt.Println(string(jsonData))
 
 	// Create a new, empty world.
 	newWorld := ecs.NewWorld()
@@ -33,10 +33,5 @@ func Example() {
 		fmt.Printf("could not deserialize: %s\n", err)
 		return
 	}
-	// Output: {"Components" : [
-	// ],
-	// "Entities" : [
-	// ],
-	// "Resources" : {
-	// }}
+	// Output:
 }

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,9 @@ go 1.21
 toolchain go1.21.3
 
 require (
-	github.com/mlange-42/arche v0.9.1-0.20240110172558-5d8643da824f
+	github.com/mlange-42/arche v0.9.1-0.20240111004217-60c5ecae4129
 	github.com/stretchr/testify v1.8.2
 )
-
-replace github.com/mlange-42/arche v0.9.1-0.20240110172558-5d8643da824f => ../arche
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.3
 
 require (
-	github.com/mlange-42/arche v0.9.1-0.20240111110009-a40af3c6cc25
+	github.com/mlange-42/arche v0.9.1-0.20240111181605-78aad37451c7
 	github.com/stretchr/testify v1.8.2
 )
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,8 @@ require (
 	github.com/stretchr/testify v1.8.2
 )
 
+replace github.com/mlange-42/arche v0.9.1-0.20240110172558-5d8643da824f => ../arche
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.3
 
 require (
-	github.com/mlange-42/arche v0.9.1-0.20240111004217-60c5ecae4129
+	github.com/mlange-42/arche v0.9.1-0.20240111110009-a40af3c6cc25
 	github.com/stretchr/testify v1.8.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/mlange-42/arche v0.9.1-0.20240110172558-5d8643da824f h1:pdioqSP4WEiHEF+/v7QHoiohwxlCmfILMSNwOJnlgO8=
-github.com/mlange-42/arche v0.9.1-0.20240110172558-5d8643da824f/go.mod h1:Bc4xbLsOifSzotIeXOvIKwsrwgzxyDhH3UIxE7vh1q0=
+github.com/mlange-42/arche v0.9.1-0.20240111004217-60c5ecae4129 h1:JHq9Snh8HoPin0Xf+3hYdD3FOYtyrh6wfnceFC70cgI=
+github.com/mlange-42/arche v0.9.1-0.20240111004217-60c5ecae4129/go.mod h1:Bc4xbLsOifSzotIeXOvIKwsrwgzxyDhH3UIxE7vh1q0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/mlange-42/arche v0.9.1-0.20240111004217-60c5ecae4129 h1:JHq9Snh8HoPin0Xf+3hYdD3FOYtyrh6wfnceFC70cgI=
-github.com/mlange-42/arche v0.9.1-0.20240111004217-60c5ecae4129/go.mod h1:Bc4xbLsOifSzotIeXOvIKwsrwgzxyDhH3UIxE7vh1q0=
+github.com/mlange-42/arche v0.9.1-0.20240111110009-a40af3c6cc25 h1:e5KyiDuLMafwSP0MLWtTFEJewshyBA/9Hpq8jfDau7A=
+github.com/mlange-42/arche v0.9.1-0.20240111110009-a40af3c6cc25/go.mod h1:Bc4xbLsOifSzotIeXOvIKwsrwgzxyDhH3UIxE7vh1q0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/mlange-42/arche v0.9.1-0.20240111110009-a40af3c6cc25 h1:e5KyiDuLMafwSP0MLWtTFEJewshyBA/9Hpq8jfDau7A=
-github.com/mlange-42/arche v0.9.1-0.20240111110009-a40af3c6cc25/go.mod h1:Bc4xbLsOifSzotIeXOvIKwsrwgzxyDhH3UIxE7vh1q0=
+github.com/mlange-42/arche v0.9.1-0.20240111181605-78aad37451c7 h1:GLXjYPSNPeeYjEYbKS6CgWjwwcqq8yeFfUU8+VC2rOQ=
+github.com/mlange-42/arche v0.9.1-0.20240111181605-78aad37451c7/go.mod h1:Bc4xbLsOifSzotIeXOvIKwsrwgzxyDhH3UIxE7vh1q0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/serialize.go
+++ b/serialize.go
@@ -9,6 +9,8 @@ import (
 	"github.com/mlange-42/arche/ecs"
 )
 
+const entityTag = "this.Entity"
+
 // Serialize an Arche ECS world to JSON.
 func Serialize(world *ecs.World) ([]byte, error) {
 	builder := strings.Builder{}
@@ -33,6 +35,7 @@ func Serialize(world *ecs.World) ([]byte, error) {
 	}
 
 	builder.WriteString("],\n\"Entities\" : [\n")
+
 	query := world.Query(ecs.All())
 	lastEntity := query.Count() - 1
 	counter = 0
@@ -41,6 +44,18 @@ func Serialize(world *ecs.World) ([]byte, error) {
 
 		ids := query.Ids()
 		last := len(ids) - 1
+
+		jsonData, err := json.Marshal(query.Entity())
+		if err != nil {
+			return nil, err
+		}
+		builder.WriteString(fmt.Sprintf("    \"%s\" : ", entityTag))
+		builder.WriteString(string(jsonData))
+		if last >= 0 {
+			builder.WriteString(",")
+		}
+		builder.WriteString("\n")
+
 		for i, id := range ids {
 			tp, _ := ecs.ComponentType(world, id)
 
@@ -50,8 +65,7 @@ func Serialize(world *ecs.World) ([]byte, error) {
 			if err != nil {
 				return nil, err
 			}
-			builder.WriteString("    ")
-			builder.WriteString(fmt.Sprintf("\"%s\" : ", tp.String()))
+			builder.WriteString(fmt.Sprintf("    \"%s\" : ", tp.String()))
 			builder.WriteString(string(jsonData))
 			if i < last {
 				builder.WriteString(",")

--- a/serialize.go
+++ b/serialize.go
@@ -184,6 +184,7 @@ func serializeResources(world *ecs.World, builder *strings.Builder) error {
 			builder.WriteString(",")
 		}
 		builder.WriteString("\n")
+		counter++
 	}
 
 	builder.WriteString("}")

--- a/serialize.go
+++ b/serialize.go
@@ -44,7 +44,12 @@ func Serialize(world *ecs.World) ([]byte, error) {
 }
 
 func serializeWorld(world *ecs.World, builder *strings.Builder) error {
-	jsonData, err := world.MarshalEntities()
+	entities := world.GetEntityData()
+
+	jsonData, err := json.Marshal(entities)
+	if err != nil {
+		return err
+	}
 	if err != nil {
 		return err
 	}

--- a/serialize.go
+++ b/serialize.go
@@ -25,11 +25,6 @@ func Serialize(world *ecs.World) ([]byte, error) {
 	serializeTypes(world, &builder)
 	builder.WriteString(",\n")
 
-	if err := serializeEntities(world, &builder); err != nil {
-		return nil, err
-	}
-	builder.WriteString(",\n")
-
 	if err := serializeComponents(world, &builder); err != nil {
 		return nil, err
 	}
@@ -80,31 +75,6 @@ func serializeTypes(world *ecs.World, builder *strings.Builder) {
 	builder.WriteString("]")
 }
 
-func serializeEntities(world *ecs.World, builder *strings.Builder) error {
-
-	builder.WriteString("\"Entities\" : [\n")
-
-	query := world.Query(ecs.All())
-	lastEntity := query.Count() - 1
-	counter := 0
-	for query.Next() {
-		jsonData, err := json.Marshal(query.Entity())
-		if err != nil {
-			return err
-		}
-		builder.WriteString(fmt.Sprintf("    %s", jsonData))
-		if counter < lastEntity {
-			builder.WriteString(",")
-		}
-		builder.WriteString("\n")
-
-		counter++
-	}
-	builder.WriteString("]")
-
-	return nil
-}
-
 func serializeComponents(world *ecs.World, builder *strings.Builder) error {
 
 	builder.WriteString("\"Components\" : [\n")
@@ -123,7 +93,7 @@ func serializeComponents(world *ecs.World, builder *strings.Builder) error {
 
 			if info.IsRelation {
 				target := query.Relation(id)
-				builder.WriteString(fmt.Sprintf("    \"%s\" : {\"ID\": %d, \"Gen\": %d},\n", targetTag, target.ID(), target.Gen()))
+				builder.WriteString(fmt.Sprintf("    \"%s\" : [%d,%d],\n", targetTag, target.ID(), target.Gen()))
 			}
 
 			comp := query.Get(id)

--- a/serialize.go
+++ b/serialize.go
@@ -9,13 +9,49 @@ import (
 	"github.com/mlange-42/arche/ecs"
 )
 
-const entityTag = "this.Entity"
-
 // Serialize an Arche ECS world to JSON.
 func Serialize(world *ecs.World) ([]byte, error) {
 	builder := strings.Builder{}
 
-	builder.WriteString("{\"Components\" : [\n")
+	builder.WriteString("{\n")
+
+	if err := serializeWorld(world, &builder); err != nil {
+		return nil, err
+	}
+	builder.WriteString(",\n")
+
+	serializeTypes(world, &builder)
+	builder.WriteString(",\n")
+
+	if err := serializeEntities(world, &builder); err != nil {
+		return nil, err
+	}
+	builder.WriteString(",\n")
+
+	if err := serializeComponents(world, &builder); err != nil {
+		return nil, err
+	}
+	builder.WriteString(",\n")
+
+	if err := serializeResources(world, &builder); err != nil {
+		return nil, err
+	}
+	builder.WriteString("}\n")
+
+	return []byte(builder.String()), nil
+}
+
+func serializeWorld(world *ecs.World, builder *strings.Builder) error {
+	jsonData, err := world.MarshalEntities()
+	if err != nil {
+		return err
+	}
+	builder.WriteString(fmt.Sprintf("\"World\" : %s", string(jsonData)))
+	return nil
+}
+
+func serializeTypes(world *ecs.World, builder *strings.Builder) {
+	builder.WriteString("\"Types\" : [\n")
 
 	types := map[ecs.ID]reflect.Type{}
 	for i := 0; i < ecs.MaskTotalBits; i++ {
@@ -34,27 +70,46 @@ func Serialize(world *ecs.World) ([]byte, error) {
 		counter++
 	}
 
-	builder.WriteString("],\n\"Entities\" : [\n")
+	builder.WriteString("]")
+}
+
+func serializeEntities(world *ecs.World, builder *strings.Builder) error {
+
+	builder.WriteString("\"Entities\" : [\n")
 
 	query := world.Query(ecs.All())
 	lastEntity := query.Count() - 1
-	counter = 0
+	counter := 0
+	for query.Next() {
+		jsonData, err := json.Marshal(query.Entity())
+		if err != nil {
+			return err
+		}
+		builder.WriteString(fmt.Sprintf("    %s", jsonData))
+		if counter < lastEntity {
+			builder.WriteString(",")
+		}
+		builder.WriteString("\n")
+
+		counter++
+	}
+	builder.WriteString("]")
+
+	return nil
+}
+
+func serializeComponents(world *ecs.World, builder *strings.Builder) error {
+
+	builder.WriteString("\"Components\" : [\n")
+
+	query := world.Query(ecs.All())
+	lastEntity := query.Count() - 1
+	counter := 0
 	for query.Next() {
 		builder.WriteString("  {\n")
 
 		ids := query.Ids()
 		last := len(ids) - 1
-
-		jsonData, err := json.Marshal(query.Entity())
-		if err != nil {
-			return nil, err
-		}
-		builder.WriteString(fmt.Sprintf("    \"%s\" : ", entityTag))
-		builder.WriteString(string(jsonData))
-		if last >= 0 {
-			builder.WriteString(",")
-		}
-		builder.WriteString("\n")
 
 		for i, id := range ids {
 			tp, _ := ecs.ComponentType(world, id)
@@ -63,7 +118,7 @@ func Serialize(world *ecs.World) ([]byte, error) {
 			value := reflect.NewAt(tp, comp).Interface()
 			jsonData, err := json.Marshal(value)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			builder.WriteString(fmt.Sprintf("    \"%s\" : ", tp.String()))
 			builder.WriteString(string(jsonData))
@@ -81,7 +136,13 @@ func Serialize(world *ecs.World) ([]byte, error) {
 
 		counter++
 	}
-	builder.WriteString("],\n\"Resources\" : {\n")
+	builder.WriteString("]")
+
+	return nil
+}
+
+func serializeResources(world *ecs.World, builder *strings.Builder) error {
+	builder.WriteString("\"Resources\" : {\n")
 
 	resTypes := map[ecs.ResID]reflect.Type{}
 	for i := 0; i < ecs.MaskTotalBits; i++ {
@@ -91,7 +152,7 @@ func Serialize(world *ecs.World) ([]byte, error) {
 	}
 
 	last := len(resTypes) - 1
-	counter = 0
+	counter := 0
 	for id, tp := range resTypes {
 		res := world.Resources().Get(id)
 		rValue := reflect.ValueOf(res)
@@ -100,7 +161,7 @@ func Serialize(world *ecs.World) ([]byte, error) {
 		value := reflect.NewAt(tp, ptr).Interface()
 		jsonData, err := json.Marshal(value)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		builder.WriteString("    ")
@@ -113,7 +174,7 @@ func Serialize(world *ecs.World) ([]byte, error) {
 		builder.WriteString("\n")
 	}
 
-	builder.WriteString("}}")
+	builder.WriteString("}")
 
-	return []byte(builder.String()), nil
+	return nil
 }

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -43,7 +43,9 @@ func TestSerialize(t *testing.T) {
 	)
 
 	resId := ecs.ResourceID[Velocity](&w)
+	resId2 := ecs.ResourceID[Position](&w)
 	w.Resources().Add(resId, &Velocity{X: 1000, Y: 0})
+	w.Resources().Add(resId2, &Position{X: 1000, Y: 0})
 
 	jsonData, err := archeserde.Serialize(&w)
 
@@ -57,6 +59,7 @@ func TestSerialize(t *testing.T) {
 	posId = ecs.ComponentID[Position](&w)
 	velId = ecs.ComponentID[Velocity](&w)
 	childId = ecs.ComponentID[ChildOf](&w)
+	_ = ecs.AddResource[Position](&w, &Position{})
 	_ = ecs.AddResource[Velocity](&w, &Velocity{})
 
 	err = archeserde.Deserialize(jsonData, &w)

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -30,11 +30,11 @@ func TestSerialize(t *testing.T) {
 	velId := ecs.ComponentID[Velocity](&w)
 	parId := ecs.ComponentID[Parent](&w)
 
-	p := w.NewEntityWith(ecs.Component{ID: posId, Comp: &Position{X: 1, Y: 2}})
-	_ = w.NewEntityWith(
+	parent := w.NewEntityWith(ecs.Component{ID: posId, Comp: &Position{X: 1, Y: 2}})
+	child := w.NewEntityWith(
 		ecs.Component{ID: posId, Comp: &Position{X: 3, Y: 4}},
 		ecs.Component{ID: velId, Comp: &Velocity{X: 5, Y: 6}},
-		ecs.Component{ID: parId, Comp: &Parent{Entity: p}},
+		ecs.Component{ID: parId, Comp: &Parent{Entity: parent}},
 	)
 
 	resId := ecs.ResourceID[Velocity](&w)
@@ -73,8 +73,12 @@ func TestSerialize(t *testing.T) {
 	assert.True(t, query.Has(velId))
 	assert.Equal(t, *(*Position)(query.Get(posId)), Position{X: 3, Y: 4})
 	assert.Equal(t, *(*Velocity)(query.Get(velId)), Velocity{X: 5, Y: 6})
+	assert.Equal(t, *(*Parent)(query.Get(parId)), Parent{Entity: parent})
 
 	res := (*Velocity)(ecs.GetResource[Velocity](&w))
 
 	assert.Equal(t, *res, Velocity{X: 1000})
+
+	assert.True(t, w.Alive(parent))
+	assert.True(t, w.Alive(child))
 }

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -112,7 +112,7 @@ func TestSerializeRelation(t *testing.T) {
 	}
 
 	w = ecs.NewWorld()
-	posId = ecs.ComponentID[Position](&w)
+	_ = ecs.ComponentID[Position](&w)
 	relId = ecs.ComponentID[ChildRelation](&w)
 
 	err = archeserde.Deserialize(jsonData, &w)

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -19,14 +19,23 @@ type Velocity struct {
 	Y float64
 }
 
+type Parent struct {
+	Entity ecs.Entity
+}
+
 func TestSerialize(t *testing.T) {
 	w := ecs.NewWorld()
 
 	posId := ecs.ComponentID[Position](&w)
 	velId := ecs.ComponentID[Velocity](&w)
+	parId := ecs.ComponentID[Parent](&w)
 
-	_ = w.NewEntityWith(ecs.Component{ID: posId, Comp: &Position{X: 1, Y: 2}})
-	_ = w.NewEntityWith(ecs.Component{ID: posId, Comp: &Position{X: 3, Y: 4}}, ecs.Component{ID: velId, Comp: &Velocity{X: 5, Y: 6}})
+	p := w.NewEntityWith(ecs.Component{ID: posId, Comp: &Position{X: 1, Y: 2}})
+	_ = w.NewEntityWith(
+		ecs.Component{ID: posId, Comp: &Position{X: 3, Y: 4}},
+		ecs.Component{ID: velId, Comp: &Velocity{X: 5, Y: 6}},
+		ecs.Component{ID: parId, Comp: &Parent{Entity: p}},
+	)
 
 	resId := ecs.ResourceID[Velocity](&w)
 	w.Resources().Add(resId, &Velocity{X: 1000, Y: 0})
@@ -42,6 +51,7 @@ func TestSerialize(t *testing.T) {
 	w = ecs.NewWorld()
 	posId = ecs.ComponentID[Position](&w)
 	velId = ecs.ComponentID[Velocity](&w)
+	parId = ecs.ComponentID[Parent](&w)
 	_ = ecs.AddResource[Velocity](&w, &Velocity{})
 
 	err = archeserde.Deserialize(jsonData, &w)

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -19,8 +19,13 @@ type Velocity struct {
 	Y float64
 }
 
-type Parent struct {
+type ChildOf struct {
 	Entity ecs.Entity
+}
+
+type ChildRelation struct {
+	ecs.Relation
+	Dummy int
 }
 
 func TestSerialize(t *testing.T) {
@@ -28,13 +33,13 @@ func TestSerialize(t *testing.T) {
 
 	posId := ecs.ComponentID[Position](&w)
 	velId := ecs.ComponentID[Velocity](&w)
-	parId := ecs.ComponentID[Parent](&w)
+	childId := ecs.ComponentID[ChildOf](&w)
 
 	parent := w.NewEntityWith(ecs.Component{ID: posId, Comp: &Position{X: 1, Y: 2}})
 	child := w.NewEntityWith(
 		ecs.Component{ID: posId, Comp: &Position{X: 3, Y: 4}},
 		ecs.Component{ID: velId, Comp: &Velocity{X: 5, Y: 6}},
-		ecs.Component{ID: parId, Comp: &Parent{Entity: parent}},
+		ecs.Component{ID: childId, Comp: &ChildOf{Entity: parent}},
 	)
 
 	resId := ecs.ResourceID[Velocity](&w)
@@ -51,7 +56,7 @@ func TestSerialize(t *testing.T) {
 	w = ecs.NewWorld()
 	posId = ecs.ComponentID[Position](&w)
 	velId = ecs.ComponentID[Velocity](&w)
-	parId = ecs.ComponentID[Parent](&w)
+	childId = ecs.ComponentID[ChildOf](&w)
 	_ = ecs.AddResource[Velocity](&w, &Velocity{})
 
 	err = archeserde.Deserialize(jsonData, &w)
@@ -73,7 +78,7 @@ func TestSerialize(t *testing.T) {
 	assert.True(t, query.Has(velId))
 	assert.Equal(t, *(*Position)(query.Get(posId)), Position{X: 3, Y: 4})
 	assert.Equal(t, *(*Velocity)(query.Get(velId)), Velocity{X: 5, Y: 6})
-	assert.Equal(t, *(*Parent)(query.Get(parId)), Parent{Entity: parent})
+	assert.Equal(t, *(*ChildOf)(query.Get(childId)), ChildOf{Entity: parent})
 
 	res := (*Velocity)(ecs.GetResource[Velocity](&w))
 
@@ -81,4 +86,40 @@ func TestSerialize(t *testing.T) {
 
 	assert.True(t, w.Alive(parent))
 	assert.True(t, w.Alive(child))
+}
+
+func TestSerializeRelation(t *testing.T) {
+	w := ecs.NewWorld()
+
+	posId := ecs.ComponentID[Position](&w)
+	relId := ecs.ComponentID[ChildRelation](&w)
+
+	parent := w.NewEntityWith(ecs.Component{ID: posId, Comp: &Position{X: 1, Y: 2}})
+	child1 := w.NewEntityWith(
+		ecs.Component{ID: posId, Comp: &Position{X: 3, Y: 4}},
+		ecs.Component{ID: relId, Comp: &ChildRelation{}},
+	)
+	child2 := w.NewEntityWith(
+		ecs.Component{ID: posId, Comp: &Position{X: 5, Y: 6}},
+		ecs.Component{ID: relId, Comp: &ChildRelation{}},
+	)
+
+	w.Relations().Set(child2, relId, parent)
+
+	jsonData, err := archeserde.Serialize(&w)
+	if err != nil {
+		assert.Fail(t, "could not serialize: %s\n", err)
+	}
+
+	w = ecs.NewWorld()
+	posId = ecs.ComponentID[Position](&w)
+	relId = ecs.ComponentID[ChildRelation](&w)
+
+	err = archeserde.Deserialize(jsonData, &w)
+	if err != nil {
+		assert.Fail(t, "could not deserialize: %s\n", err)
+	}
+
+	assert.Equal(t, w.Relations().Get(child1, relId), ecs.Entity{})
+	assert.Equal(t, w.Relations().Get(child2, relId), parent)
 }

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -110,6 +110,7 @@ func TestSerializeRelation(t *testing.T) {
 	if err != nil {
 		assert.Fail(t, "could not serialize: %s\n", err)
 	}
+	fmt.Println(string(jsonData))
 
 	w = ecs.NewWorld()
 	_ = ecs.ComponentID[Position](&w)

--- a/types.go
+++ b/types.go
@@ -18,3 +18,8 @@ func (e *entry) UnmarshalJSON(jsonData []byte) error {
 func (e *entry) String() string {
 	return string(e.Bytes)
 }
+
+type entity struct {
+	ID  uint32 `json:".ID"`
+	Gen uint32 `json:".Gen"`
+}

--- a/types.go
+++ b/types.go
@@ -3,7 +3,7 @@ package archeserde
 import "github.com/mlange-42/arche/ecs"
 
 type deserializer struct {
-	World      entry
+	World      ecs.EntityData
 	Types      []string
 	Entities   []ecs.Entity
 	Components []entry

--- a/types.go
+++ b/types.go
@@ -1,8 +1,12 @@
 package archeserde
 
+import "github.com/mlange-42/arche/ecs"
+
 type deserializer struct {
-	Components []string
-	Entities   []entry
+	World      entry
+	Types      []string
+	Entities   []ecs.Entity
+	Components []entry
 	Resources  map[string]entry
 }
 
@@ -17,9 +21,4 @@ func (e *entry) UnmarshalJSON(jsonData []byte) error {
 
 func (e *entry) String() string {
 	return string(e.Bytes)
-}
-
-type entity struct {
-	ID  uint32 `json:".ID"`
-	Gen uint32 `json:".Gen"`
 }

--- a/types.go
+++ b/types.go
@@ -18,7 +18,3 @@ func (e *entry) UnmarshalJSON(jsonData []byte) error {
 	e.Bytes = jsonData
 	return nil
 }
-
-func (e *entry) String() string {
-	return string(e.Bytes)
-}

--- a/types.go
+++ b/types.go
@@ -5,7 +5,6 @@ import "github.com/mlange-42/arche/ecs"
 type deserializer struct {
 	World      ecs.EntityData
 	Types      []string
-	Entities   []ecs.Entity
 	Components []entry
 	Resources  map[string]entry
 }


### PR DESCRIPTION
Entities in the Arche `World` are restored to exactly the same state (ID, generation, alive) as in the serialized world.

Targets of `ecs.Relation` components are serialized and deserialized properly.
All stored entities in components and resources should also remain valid.